### PR TITLE
Validator better handles expected package registry format.

### DIFF
--- a/hatch_validator/__init__.py
+++ b/hatch_validator/__init__.py
@@ -4,7 +4,7 @@ Hatch-Validator package for validating Hatch packages and dependencies.
 This package provides tools for validating Hatch packages, their metadata, and dependencies.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from .package_validator import HatchPackageValidator, PackageValidationError
 from .dependency_resolver import DependencyResolver, DependencyResolutionError

--- a/hatch_validator/dependency_resolver.py
+++ b/hatch_validator/dependency_resolver.py
@@ -20,11 +20,12 @@ class DependencyResolver:
         """Initialize the Dependency resolver.
         
         Args:
-            registry_data: Optional registry data to use for dependency resolution
+            registry_data: Registry data to use for dependency resolution
         """
         self.logger = logging.getLogger("hatch.dependency_resolver")
         self.logger.setLevel(logging.INFO)
         self.registry_data = registry_data
+        self._package_cache = {}  # Cache for reconstructed package data
     
     def _parse_version_constraint(self, version_spec: str) -> Tuple[Optional[str], Optional[str]]:
         """Parse a version constraint string into operator and version"""
@@ -94,14 +95,12 @@ class DependencyResolver:
             raise DependencyResolutionError(f"Error reading metadata: {e}")
     
     def validate_dependencies(self, dependencies: List[Dict], 
-                            available_packages: Dict[str, Dict] = None,
                             package_dir: Optional[Path] = None) -> Tuple[bool, List[str]]:
         """
-        Validate all dependencies (local and remote) using a flat, queue-based approach.
+        Validate all dependencies (local and remote) using registry data as source of truth.
         
         Args:
             dependencies: List of all dependency definitions
-            available_packages: Dictionary of available packages by name
             package_dir: Optional base directory for resolving file:// URIs
             
         Returns:
@@ -112,9 +111,8 @@ class DependencyResolver:
         validated = set()  # Track processed dependencies by name
         is_valid = True
         
-        # Initialize available packages if not provided
-        if available_packages is None:
-            available_packages = {}
+        if not self.registry_data:
+            self.logger.warning("No registry data available for remote dependency validation")
         
         while to_validate:
             dep = to_validate.popleft()
@@ -154,7 +152,7 @@ class DependencyResolver:
                         to_validate.append(trans_dep)
                         
             elif dep_type == 'remote':
-                remote_valid, remote_dep_errors = self._validate_remote_dependency(dep, available_packages)
+                remote_valid, remote_dep_errors = self._validate_remote_dependency(dep)
                 if not remote_valid:
                     errors.extend(remote_dep_errors)
                     is_valid = False
@@ -234,13 +232,12 @@ class DependencyResolver:
             
         return is_valid, errors, transitive_deps
     
-    def _validate_remote_dependency(self, dep: Dict, available_packages: Dict) -> Tuple[bool, List[str]]:
+    def _validate_remote_dependency(self, dep: Dict) -> Tuple[bool, List[str]]:
         """
-        Validate a remote dependency against available packages.
+        Validate a remote dependency against registry data.
         
         Args:
             dep: Remote dependency definition
-            available_packages: Dictionary of available packages by name
             
         Returns:
             Tuple[bool, List[str]]: (is_valid, errors)
@@ -253,34 +250,41 @@ class DependencyResolver:
 
         self.logger.debug(f"Validating remote dependency '{dep_name}' (version {version_constraint})")
         
-        # Check if the package exists
-        if dep_name not in available_packages:
-            error_msg = f"Remote dependency '{dep_name}' not found in available packages"
+        # Check if registry data is available
+        if not self.registry_data:
+            error_msg = f"No registry data available to validate remote dependency '{dep_name}'"
+            self.logger.error(error_msg)
+            errors.append(error_msg)
+            return False, errors
+        
+        # Find the package in registry
+        package_data = self.find_package_in_registry(dep_name)
+        if not package_data:
+            error_msg = f"Remote dependency '{dep_name}' not found in registry"
             self.logger.error(error_msg)
             errors.append(error_msg)
             return False, errors
             
-        # Check version constraint against installed version
+        # If version constraint is provided, check compatibility
         if version_constraint:
-            installed_version = available_packages[dep_name].get('version')
-            if installed_version:
-                if not self.is_version_compatible(installed_version, version_constraint):
-                    error_msg = f"Remote dependency '{dep_name}' version {installed_version} does not satisfy constraint {version_constraint}"
-                    self.logger.error(error_msg)
-                    errors.append(error_msg)
-                    is_valid = False
+            version_data = self.get_package_version(dep_name, version_constraint)
+            if not version_data:
+                error_msg = f"No version of '{dep_name}' satisfies constraint {version_constraint}"
+                self.logger.error(error_msg)
+                errors.append(error_msg)
+                is_valid = False
+            else:
+                self.logger.debug(f"Found compatible version {version_data['version']} for '{dep_name}'")
                     
         return is_valid, errors
     
     def _build_dependency_graph(self, dependencies: List[Dict], 
-                              available_packages: Dict[str, Dict] = None,
                               package_dir: Optional[Path] = None) -> Dict[str, List[str]]:
         """
-        Build a complete dependency graph from initial dependencies.
+        Build a complete dependency graph from initial dependencies using registry data.
         
         Args:
             dependencies: List of dependency definitions
-            available_packages: Dictionary of available packages by name
             package_dir: Optional base directory for resolving file:// URIs
             
         Returns:
@@ -289,10 +293,6 @@ class DependencyResolver:
         dependency_graph = {}  # name -> list of dependencies
         unprocessed = deque([(dep.get('name'), dep) for dep in dependencies if dep.get('name')])
         processed = set()
-        
-        # Initialize available packages if not provided
-        if available_packages is None:
-            available_packages = {}
         
         while unprocessed:
             
@@ -337,39 +337,51 @@ class DependencyResolver:
                     except Exception as e:
                         self.logger.debug(f"Error processing local dependency '{dep_name}': {str(e)}")
             
-            # For remote dependencies, check registry
+            # For remote dependencies, use registry data
             else:
-                if dep_name in available_packages:
-                    try:
-                        next_deps = available_packages[dep_name].get('hatch_dependencies', [])
-                        dependency_graph[dep_name] += [d['name'] for d in next_deps]
-                        # Add to unprocessed for further processing
-                        unprocessed.extend([(d['name'], d) for d in next_deps])
-                    except Exception as e:
-                        self.logger.debug(f"Error processing remote dependency '{dep_name}': {str(e)}")
-                else:
-                    self.logger.debug(f"Remote dependency '{dep_name}' not found in available packages")
+                try:
+                    # Get latest version or matching version from registry
+                    version_constraint = dep_info.get('version_constraint')
+                    version_data = self.get_package_version(dep_name, version_constraint)
+                    
+                    if version_data:
+                        # Reconstruct full dependencies from registry data
+                        package_data = self.find_package_in_registry(dep_name)
+                        if package_data:
+                            # Get dependencies for this version
+                            deps_data = self.get_full_package_dependencies(dep_name, version_data["version"])
+                            next_deps = deps_data.get("dependencies", [])
+                            
+                            # Add to graph
+                            for d in next_deps:
+                                d_name = d.get('name')
+                                if d_name:
+                                    dependency_graph[dep_name].append(d_name)
+                                    
+                                    # Add to unprocessed queue
+                                    if d_name not in processed:
+                                        unprocessed.append((d_name, d))
+                except Exception as e:
+                    self.logger.debug(f"Error processing remote dependency '{dep_name}' from registry: {str(e)}")
         
         self.logger.debug(f"Final dependency graph: {dependency_graph}")
 
         return dependency_graph
     
     def detect_dependency_cycles(self, dependencies: List[Dict], 
-                               available_packages: Dict[str, Dict] = None,
                                package_dir: Optional[Path] = None) -> Tuple[bool, List[List[str]]]:
         """
-        Detect circular dependencies in the dependency graph.
+        Detect circular dependencies in the dependency graph using registry data.
         
         Args:
             dependencies: List of dependency definitions
-            available_packages: Dictionary of available packages by name
             package_dir: Optional base directory for resolving file:// URIs
             
         Returns:
             Tuple[bool, List[List[str]]]: (has_cycles, list_of_cycles)
         """
         # Build complete dependency graph first
-        dependency_graph = self._build_dependency_graph(dependencies, available_packages, package_dir)
+        dependency_graph = self._build_dependency_graph(dependencies, package_dir)
         cycles = []
         
         # Helper function to find cycles using DFS
@@ -581,3 +593,75 @@ class DependencyResolver:
             self.logger.error(f"Failed to load registry: {e}")
             self.registry_data = {"repositories": []}
             return False
+    
+    def find_package_in_registry(self, package_name: str) -> Optional[Dict]:
+        """
+        Find a package in the registry data.
+        
+        Args:
+            package_name: Name of the package to find
+            
+        Returns:
+            Optional[Dict]: Package data if found, None otherwise
+        """
+        if not self.registry_data:
+            self.logger.error("No registry data provided")
+            return None
+            
+        for repo in self.registry_data.get("repositories", []):
+            for pkg in repo.get("packages", []):
+                if pkg["name"] == package_name:
+                    return pkg
+        
+        return None
+        
+    def get_package_version(self, package_name: str, version_constraint: str = None) -> Optional[Dict]:
+        """
+        Get package version data from registry that satisfies the given constraint.
+        If no constraint is provided, returns the latest version.
+        
+        Args:
+            package_name: Name of the package
+            version_constraint: Optional version constraint
+            
+        Returns:
+            Optional[Dict]: Version data if found, None otherwise
+        """
+        package_data = self.find_package_in_registry(package_name)
+        if not package_data:
+            return None
+            
+        if not version_constraint:
+            # Return the latest version
+            latest_version = package_data.get("latest_version")
+            if not latest_version:
+                return None
+                
+            for ver_data in package_data.get("versions", []):
+                if ver_data["version"] == latest_version:
+                    return ver_data
+            return None
+        
+        # Find a version that satisfies the constraint
+        try:
+            req_spec = specifiers.SpecifierSet(version_constraint)
+            valid_versions = []
+            
+            for ver_data in package_data.get("versions", []):
+                if req_spec.contains(ver_data["version"]):
+                    valid_versions.append((ver_data["version"], ver_data))
+                    
+            if not valid_versions:
+                return None
+                
+            # Return the highest matching version
+            valid_versions.sort(key=lambda x: version.parse(x[0]), reverse=True)
+            return valid_versions[0][1]
+            
+        except Exception as e:
+            self.logger.error(f"Error finding compatible version for {package_name}: {e}")
+            return None
+    
+    def clear_cache(self):
+        """Clear the internal package cache"""
+        self._package_cache = {}

--- a/hatch_validator/package_validator.py
+++ b/hatch_validator/package_validator.py
@@ -143,7 +143,8 @@ class HatchPackageValidator:
             
         return all_exist, errors
     
-    def validate_dependencies(self, metadata: Dict, package_dir: Optional[Path] = None) -> Tuple[bool, List[str]]: 
+    def validate_dependencies(self, metadata: Dict, package_dir: Optional[Path] = None,
+                         pending_update: Optional[Tuple[str, Dict]] = None) -> Tuple[bool, List[str]]: 
         """
         Validate that all dependencies specified in metadata exist and are compatible.
         Uses registry data as source of truth for remote dependencies.
@@ -151,6 +152,7 @@ class HatchPackageValidator:
         Args:
             metadata: Package metadata
             package_dir: Optional path to package directory for resolving local dependencies
+            pending_update: Optional tuple (pkg_name, metadata) with pending update information
             
         Returns:
             Tuple[bool, List[str]]: (is_valid, list of validation errors)
@@ -186,7 +188,8 @@ class HatchPackageValidator:
         try:
             has_cycles, cycles = self.dependency_resolver.detect_dependency_cycles(
                 hatch_dependencies,
-                package_dir
+                package_dir,
+                pending_update
             )
             if has_cycles:
                 for cycle in cycles:
@@ -199,13 +202,14 @@ class HatchPackageValidator:
         
         return is_valid, errors
         
-    def validate_package(self, package_dir: Path) -> Tuple[bool, Dict[str, Any]]: 
+    def validate_package(self, package_dir: Path, pending_update: Optional[Tuple[str, Dict]] = None) -> Tuple[bool, Dict[str, Any]]: 
         """
         Validate a Hatch package in the specified directory.
         Uses registry data for remote dependencies validation.
         
         Args:
             package_dir: Path to the package directory
+            pending_update: Optional tuple (pkg_name, metadata) with pending update information
             
         Returns:
             Tuple[bool, Dict[str, Any]]: (is_valid, validation results)
@@ -256,7 +260,7 @@ class HatchPackageValidator:
         
         # Validate dependencies using registry data
         deps_valid, deps_errors = self._run_validation(
-            self.validate_dependencies, metadata, package_dir
+            self.validate_dependencies, metadata, package_dir, pending_update
         )
         results['dependencies']['valid'] = deps_valid
         results['dependencies']['errors'] = deps_errors

--- a/hatch_validator/package_validator.py
+++ b/hatch_validator/package_validator.py
@@ -4,7 +4,6 @@ import logging
 import jsonschema
 from pathlib import Path
 from typing import Dict, List, Tuple, Any, Optional, Callable
-from packaging import specifiers
 
 from .schemas_retriever import get_package_schema
 from .dependency_resolver import DependencyResolver
@@ -22,7 +21,7 @@ class HatchPackageValidator:
             version: Version of the schema to use, or "latest"
             allow_local_dependencies: Whether to allow local dependencies
             force_schema_update: Whether to force a schema update check
-            registry_data: Optional registry data to use for dependency validation
+            registry_data: Registry data to use for dependency validation
         """
         self.logger = logging.getLogger("hatch.package_validator")
         self.logger.setLevel(logging.INFO)
@@ -144,14 +143,14 @@ class HatchPackageValidator:
             
         return all_exist, errors
     
-    def validate_dependencies(self, metadata: Dict, available_packages: Dict[str, Dict] = None) -> Tuple[bool, List[str]]: 
+    def validate_dependencies(self, metadata: Dict, package_dir: Optional[Path] = None) -> Tuple[bool, List[str]]: 
         """
         Validate that all dependencies specified in metadata exist and are compatible.
-        Delegates to DependencyResolver for comprehensive validation.
+        Uses registry data as source of truth for remote dependencies.
         
         Args:
             metadata: Package metadata
-            available_packages: Dictionary of available packages by name
+            package_dir: Optional path to package directory for resolving local dependencies
             
         Returns:
             Tuple[bool, List[str]]: (is_valid, list of validation errors)
@@ -173,10 +172,10 @@ class HatchPackageValidator:
                 is_valid = False
                 return is_valid, errors
         
-        # Use the enhanced DependencyResolver for validation
+        # Use the dependency resolver for validation
         validation_valid, validation_errors = self.dependency_resolver.validate_dependencies(
             hatch_dependencies,
-            available_packages
+            package_dir
         )
         
         if not validation_valid:
@@ -187,7 +186,7 @@ class HatchPackageValidator:
         try:
             has_cycles, cycles = self.dependency_resolver.detect_dependency_cycles(
                 hatch_dependencies,
-                available_packages
+                package_dir
             )
             if has_cycles:
                 for cycle in cycles:
@@ -200,13 +199,13 @@ class HatchPackageValidator:
         
         return is_valid, errors
         
-    def validate_package(self, package_dir: Path, available_packages: Dict[str, Dict] = None) -> Tuple[bool, Dict[str, Any]]: 
+    def validate_package(self, package_dir: Path) -> Tuple[bool, Dict[str, Any]]: 
         """
         Validate a Hatch package in the specified directory.
+        Uses registry data for remote dependencies validation.
         
         Args:
             package_dir: Path to the package directory
-            available_packages: Dictionary of available packages by name
             
         Returns:
             Tuple[bool, Dict[str, Any]]: (is_valid, validation results)
@@ -255,9 +254,9 @@ class HatchPackageValidator:
             results['valid'] = False
             return False, results
         
-        # Validate dependencies using enhanced resolver
+        # Validate dependencies using registry data
         deps_valid, deps_errors = self._run_validation(
-            self.validate_dependencies, metadata, available_packages
+            self.validate_dependencies, metadata, package_dir
         )
         results['dependencies']['valid'] = deps_valid
         results['dependencies']['errors'] = deps_errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch-validator"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   { name = "Hatch Team" },
 ]

--- a/tests/test_package_validator.py
+++ b/tests/test_package_validator.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 import logging
 import sys
+from datetime import datetime
 
 # Add the parent directory to the path if needed
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -25,19 +26,36 @@ class TestHatchPackageValidator(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment before each test."""
-        self.validator = HatchPackageValidator()
-        
         # Path to Hatch-Dev packages
         self.hatch_dev_path = Path(__file__).parent.parent.parent / "Hatch-Dev"
         self.assertTrue(self.hatch_dev_path.exists(), 
                         f"Hatch-Dev directory not found at {self.hatch_dev_path}")
                         
-        # Create list of available packages for dependency testing
-        self.available_packages = self._build_available_packages()
+        # Build registry data structure from Hatch-Dev packages
+        self.registry_data = self._build_test_registry()
+        logger.debug(f"Built the base test registry: {json.dumps(self.registry_data, indent=2)}")
         
-    def _build_available_packages(self):
-        """Build a list of available packages from Hatch-Dev for dependency testing."""
-        packages = {}
+        # Create validator with registry data
+        self.validator = HatchPackageValidator(registry_data=self.registry_data)
+        
+    def _build_test_registry(self):
+        """
+        Build a test registry data structure from Hatch-Dev packages for dependency testing.
+        This simulates the structure that would be expected from a real registry file.
+        """
+        # Create registry structure according to the schema
+        registry = {
+            "registry_schema_version": "1.0.0",
+            "last_updated": datetime.now().isoformat(),
+            "repositories": [
+                {
+                    "name": "Hatch-Dev",
+                    "url": "file://" + str(self.hatch_dev_path),
+                    "packages": [],
+                    "last_indexed": datetime.now().isoformat()
+                }
+            ]
+        }
         
         # Known packages in Hatch-Dev
         pkg_names = [
@@ -45,9 +63,15 @@ class TestHatchPackageValidator(unittest.TestCase):
             "base_pkg_1", 
             "base_pkg_2", 
             "python_dep_pkg",
-            "circular_dep_pkg_1"
+            "circular_dep_pkg_1",
+            "circular_dep_pkg_2",
+            "complex_dep_pkg",
+            "simple_dep_pkg",
+            "missing_dep_pkg",
+            "version_dep_pkg"
         ]
         
+        # Add each package to the registry
         for pkg_name in pkg_names:
             pkg_path = self.hatch_dev_path / pkg_name
             if pkg_path.exists():
@@ -56,11 +80,48 @@ class TestHatchPackageValidator(unittest.TestCase):
                     try:
                         with open(metadata_path, 'r') as f:
                             metadata = json.load(f)
-                            packages[pkg_name] = metadata
+                            
+                            # Create a package entry with version information
+                            pkg_entry = {
+                                "name": metadata.get("name", pkg_name),
+                                "description": metadata.get("description", ""),
+                                "category": "development",
+                                "tags": metadata.get("tags", []),
+                                "latest_version": metadata.get("version", "1.0.0"),
+                                "versions": [
+                                    {
+                                        "version": metadata.get("version", "1.0.0"),
+                                        "path": str(pkg_path),
+                                        "metadata_path": "hatch_metadata.json",
+                                        "base_version": None,  # First version has no base
+                                        "artifacts": [],
+                                        "added_date": datetime.now().isoformat(),
+                                        # Add dependencies as differential changes
+                                        "hatch_dependencies_added": [
+                                            {
+                                                "name": dep["name"],
+                                                "version_constraint": dep.get("version_constraint", "")
+                                            }
+                                            for dep in metadata.get("hatch_dependencies", [])
+                                        ],
+                                        "python_dependencies_added": [
+                                            {
+                                                "name": dep["name"],
+                                                "version_constraint": dep.get("version_constraint", ""),
+                                                "package_manager": dep.get("package_manager", "pip")
+                                            }
+                                            for dep in metadata.get("python_dependencies", [])
+                                        ],
+                                    }
+                                ]
+                            }
+                            
+                            # Add to registry
+                            registry["repositories"][0]["packages"].append(pkg_entry)
                     except Exception as e:
                         logger.warning(f"Failed to load metadata for {pkg_name}: {e}")
-        
-        return packages
+
+        return registry
     
     def test_valid_package_arithmetic(self):
         """Test validating a simple valid package (arithmetic_pkg)."""
@@ -76,22 +137,8 @@ class TestHatchPackageValidator(unittest.TestCase):
         
     def test_valid_package_with_dependencies(self):
         """Test validating a package with valid dependencies (simple_dep_pkg)."""
-        # # First make sure the dependency exists in available_packages
-        # base_pkg_path = self.hatch_dev_path / "base_pkg_1"
-        # base_metadata_path = base_pkg_path / "hatch_metadata.json"
-        # with open(base_metadata_path, 'r') as f:
-        #     base_metadata = json.load(f)
-            
-        # # Add to available packages
-        # base_pkg = {
-        #     "name": base_metadata.get("name"),
-        #     "version": base_metadata.get("version")
-        # }
-        # available_packages = self.available_packages + [base_pkg]
-        
-        # Now validate the package that depends on it
         pkg_path = self.hatch_dev_path / "simple_dep_pkg"
-        is_valid, results = self.validator.validate_package(pkg_path, self.available_packages)
+        is_valid, results = self.validator.validate_package(pkg_path)
         
         self.assertTrue(is_valid)
         self.assertTrue(results["valid"])
@@ -100,7 +147,7 @@ class TestHatchPackageValidator(unittest.TestCase):
     def test_missing_dependency(self):
         """Test validating a package with missing dependencies (missing_dep_pkg)."""
         pkg_path = self.hatch_dev_path / "missing_dep_pkg"
-        is_valid, results = self.validator.validate_package(pkg_path, self.available_packages)
+        is_valid, results = self.validator.validate_package(pkg_path)
         
         self.assertFalse(is_valid)
         self.assertFalse(results["valid"])
@@ -108,31 +155,14 @@ class TestHatchPackageValidator(unittest.TestCase):
         self.assertTrue(len(results["dependencies"]["errors"]) > 0)
         
         # Check if the error message mentions the missing dependency
-        any_error_mentions_missing = any("not found in available packages" in error 
+        any_error_mentions_missing = any("not found in registry" in error 
                                         for error in results["dependencies"]["errors"])
         self.assertTrue(any_error_mentions_missing)
     
     def test_complex_dependency_chain(self):
         """Test validating a package with complex dependency chain (complex_dep_pkg)."""
-        # Build available packages list with all required dependencies
-        # required_deps = ["base_pkg_1", "base_pkg_2", "python_dep_pkg"]
-        # available_packages = self.available_packages.copy()
-        
-        # for dep_name in required_deps:
-        #     dep_path = self.hatch_dev_path / dep_name
-        #     metadata_path = dep_path / "hatch_metadata.json"
-        #     if metadata_path.exists():
-        #         with open(metadata_path, 'r') as f:
-        #             metadata = json.load(f)
-        #             # Add or update in available packages
-        #             available_packages.append({
-        #                 "name": metadata.get("name"),
-        #                 "version": metadata.get("version")
-        #             })
-        
-        # Now validate the complex dependency package
         pkg_path = self.hatch_dev_path / "complex_dep_pkg"
-        is_valid, results = self.validator.validate_package(pkg_path, self.available_packages)
+        is_valid, results = self.validator.validate_package(pkg_path)
         
         self.assertTrue(is_valid)
         self.assertTrue(results["valid"])
@@ -140,16 +170,8 @@ class TestHatchPackageValidator(unittest.TestCase):
     
     def test_version_dependency_constraint(self):
         """Test validating a package with version-specific dependency (version_dep_pkg)."""
-        # # Add the base package with a compatible version
-        # base_pkg = {
-        #     "name": "base_pkg_1",
-        #     "version": "1.0.0"  # This should satisfy >=0.1.0
-        # }
-        # available_packages = self.available_packages + [base_pkg]
-        
-        # Validate the package with version-specific dependency
         pkg_path = self.hatch_dev_path / "version_dep_pkg"
-        is_valid, results = self.validator.validate_package(pkg_path, self.available_packages)
+        is_valid, results = self.validator.validate_package(pkg_path)
         
         self.assertTrue(is_valid)
         self.assertTrue(results["valid"])
@@ -157,79 +179,67 @@ class TestHatchPackageValidator(unittest.TestCase):
     
     def test_version_dependency_constraint_incompatible(self):
         """Test validating a package with incompatible version dependency."""
-        # Add the base package with an incompatible version
-        # base_pkg = {
-        #     "name": "base_pkg_1", 
-        #     "version": "0.0.9"  # This should NOT satisfy >=0.1.0
-        # }
+        # Create a copy of the registry with an incompatible version
+        modified_registry = self.registry_data.copy()
         
-        # Make a copy of the available packages to avoid modifying the original
-        available_packages = self.available_packages.copy()
-        # Modify the version of the base package for this test
-        self.available_packages["base_pkg_1"]["version"] = "0.0.9"
-
+        # Find base_pkg_1 in the registry
+        for repo in modified_registry["repositories"]:
+            for pkg in repo["packages"]:
+                if pkg["name"] == "base_pkg_1":
+                    # Change the version to be incompatible
+                    pkg["latest_version"] = "0.0.9"
+                    pkg["versions"][0]["version"] = "0.0.9"
+        
+        # Create a new validator with the modified registry
+        validator = HatchPackageValidator(registry_data=modified_registry)
         
         # Validate the package with version-specific dependency
         pkg_path = self.hatch_dev_path / "version_dep_pkg"
-        is_valid, results = self.validator.validate_package(pkg_path, available_packages)
+        is_valid, results = validator.validate_package(pkg_path)
         
         self.assertFalse(is_valid)
         self.assertFalse(results["valid"])
         self.assertFalse(results["dependencies"]["valid"])
         
         # Check if error message mentions version mismatch
-        any_error_mentions_version = any("does not satisfy constraint" in error 
+        any_error_mentions_version = any("satisfies constraint" in error 
                                         for error in results["dependencies"]["errors"])
         self.assertTrue(any_error_mentions_version)
         
     def test_circular_dependency_packages(self):
         """Test validating packages involved in a circular dependency."""
-        # This is testing at the package level - circular dependencies are typically
-        # detected at the registry level with multiple packages
-        
         # First package (circular_dep_pkg_1)
         pkg1_path = self.hatch_dev_path / "circular_dep_pkg_1"
-        is_valid1, results1 = self.validator.validate_package(pkg1_path, self.available_packages)
         
-        # circular_dep_pkg_1 should not be valid since it depends on circular_dep_pkg_2
-        self.assertFalse(is_valid1)
-        self.assertFalse(results1["valid"])
-        self.assertFalse(results1["dependencies"]["valid"])
+        # Create a registry with a circular dependency
+        circular_registry = self.registry_data.copy()
         
-        # Then, let's make the second package available
-        pkg2_path = self.hatch_dev_path / "circular_dep_pkg_2"
-        with open(pkg2_path / "hatch_metadata.json", 'r') as f:
-            metadata = json.load(f)
-            # make a copy of the available packages to avoid modifying the original
-            available_packages = self.available_packages.copy()
-            # Expand the copy to include the second package
-            available_packages["circular_dep_pkg_2"] = metadata
-
-        # Test the first package again with the second one available
-        is_valid1bis, results1bis = self.validator.validate_package(pkg1_path, available_packages)
-
-        self.assertTrue(is_valid1bis)
-        self.assertTrue(results1bis["valid"])
-        self.assertTrue(results1bis["dependencies"]["valid"])
-
-        # Now, modify the data of the second package to create a circular dependency
-        # Let's add a dependency field to the metadata in the available packages
-        available_packages["circular_dep_pkg_2"]["hatch_dependencies"] = [{"name": "circular_dep_pkg_1", "version": "1.0.0", "type": "remote"}]
-
-        # Finally, re-run validation for the first package
-        # This should now fail due to circular dependency
-        is_valid1ter, results1ter = self.validator.validate_package(pkg1_path, available_packages)
-
-        self.assertFalse(is_valid1ter)
-        self.assertFalse(results1ter["valid"])
-        self.assertFalse(results1ter["dependencies"]["valid"])
+        # Update circular_dep_pkg_2 to depend on circular_dep_pkg_1
+        for repo in circular_registry["repositories"]:
+            for pkg in repo["packages"]:
+                if pkg["name"] == "circular_dep_pkg_2":
+                    # Add a dependency on circular_dep_pkg_1
+                    pkg["versions"][0]["hatch_dependencies_added"].append({
+                        "name": "circular_dep_pkg_1",
+                        "version_constraint": ""
+                    })
+        
+        # Create a validator with the circular dependency registry
+        circular_validator = HatchPackageValidator(registry_data=circular_registry)
+        
+        # Validate - should detect the circular dependency
+        is_valid, results = circular_validator.validate_package(pkg1_path)
+        
+        self.assertFalse(is_valid)
+        self.assertFalse(results["valid"])
+        self.assertFalse(results["dependencies"]["valid"])
+        
+        # Check if any error message mentions circular dependency
+        any_error_mentions_circular = any("circular" in error.lower() for error in results["dependencies"]["errors"])
+        self.assertTrue(any_error_mentions_circular)
     
     def test_entry_point_not_exists(self):
         """Test validating a package with a missing entry point file."""
-        
-        #TODO: This test is self implemented, we should rely on a dummy package instead
-        # in "Hatch-Dev" to test this case. Something like "missing_entry_point_pkg"
-        
         # Create a temporary package with an invalid entry point
         temp_dir = Path(tempfile.mkdtemp())
         try:


### PR DESCRIPTION
Enhancing dependency resolution by leveraging registry data as the primary source of truth for packages marked as "remote". In the previous version, there was a conflict of intention between an input parameter `available_packages` and `registry_data`, where the former was given priority over the later. This was useful for tests but no longer necessary as the registry management matured.

Given that the registry stores package information by difference, we updated the dependency reconstruction functions and circular dependency checks.

### Updates to Dependency Resolution

* `hatch_validator/dependency_resolver.py`:
  - Introduced `find_package_in_registry` and `get_package_version` methods for retrieving package and version data from the registry. These methods replace the older approach of using `available_packages`.
  - Modified `_validate_remote_dependency` to validate dependencies directly against registry data instead of `available_packages`. [[1]](diffhunk://#diff-614df9149f18939fb60a8d097bf191157dbf7ff59230b8fceb3b8d327a1f7462L237-L243) [[2]](diffhunk://#diff-614df9149f18939fb60a8d097bf191157dbf7ff59230b8fceb3b8d327a1f7462L256-R290)
  - Updated `_build_dependency_graph` to use registry data and support pending updates for dependency processing. [[1]](diffhunk://#diff-614df9149f18939fb60a8d097bf191157dbf7ff59230b8fceb3b8d327a1f7462L293-L298) [[2]](diffhunk://#diff-614df9149f18939fb60a8d097bf191157dbf7ff59230b8fceb3b8d327a1f7462L340-R408)
* Added `_package_cache` to `DependencyResolver` for caching reconstructed package data for query performance.

### Changes in Dependency Validation Workflow

* `hatch_validator/package_validator.py`:
  - Updated `validate_dependencies` and `validate_package` methods to use registry data and support pending updates for dependency validation. [[1]](diffhunk://#diff-2b20c00ae81974d671bc4ef2f0e348ce02fdcf681f9a46688b9f01dd75c493b2L147-R155) [[2]](diffhunk://#diff-2b20c00ae81974d671bc4ef2f0e348ce02fdcf681f9a46688b9f01dd75c493b2L203-R212)
  - Removed the `available_packages` parameter in favor of registry-based validation. [[1]](diffhunk://#diff-2b20c00ae81974d671bc4ef2f0e348ce02fdcf681f9a46688b9f01dd75c493b2L176-R180) [[2]](diffhunk://#diff-2b20c00ae81974d671bc4ef2f0e348ce02fdcf681f9a46688b9f01dd75c493b2L258-R263)

### Version Updates

* Updated the package version in `hatch_validator/__init__.py` and `pyproject.toml` to `0.3.0`. [[1]](diffhunk://#diff-14125285a3abea81ceb441902affd0da15e1cf0fdcdee0c710049f582774f11aL7-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)