### PR TITLE
Support to validate schema version 1.2.1

### DIFF
--- a/hatch_validator/core/pkg_accessor_factory.py
+++ b/hatch_validator/core/pkg_accessor_factory.py
@@ -64,6 +64,12 @@ class HatchPkgAccessorFactory:
             except ImportError as e:
                 logger.warning(f"Could not load v1.2.0 accessor: {e}")
 
+            try:
+                from hatch_validator.package.v1_2_1.accessor import HatchPkgAccessor as V121HatchPkgAccessor
+                cls.register_accessor("1.2.1", V121HatchPkgAccessor)
+            except ImportError as e:
+                logger.warning(f"Could not load v1.2.1 accessor: {e}")
+
     @classmethod
     def create_accessor_chain(cls, target_version: Optional[str] = None) -> HatchPkgAccessor:
         """Create appropriate accessor chain based on target version.

--- a/hatch_validator/core/validator_factory.py
+++ b/hatch_validator/core/validator_factory.py
@@ -66,6 +66,12 @@ class ValidatorFactory:
                 cls.register_validator("1.2.0", V120Validator)
             except ImportError as e:
                 logger.warning(f"Could not load v1.2.0 validator: {e}")
+
+            try:
+                from hatch_validator.package.v1_2_1.validator import Validator as V121Validator
+                cls.register_validator("1.2.1", V121Validator)
+            except ImportError as e:
+                logger.warning(f"Could not load v1.2.1 validator: {e}")
     
     @classmethod
     def create_validator_chain(cls, target_version: Optional[str] = None) -> Validator:

--- a/hatch_validator/package/v1_2_1/__init__.py
+++ b/hatch_validator/package/v1_2_1/__init__.py
@@ -1,0 +1,6 @@
+"""Schema validation package for v1.2.1.
+
+This package contains the validator and strategies for schema version 1.2.1,
+which introduces dual entry point support (FastMCP server + HatchMCP wrapper)
+with mandatory tool enforcement in FastMCP server files.
+"""

--- a/hatch_validator/package/v1_2_1/accessor.py
+++ b/hatch_validator/package/v1_2_1/accessor.py
@@ -1,0 +1,54 @@
+"""Package metadata accessor for schema version 1.2.1.
+
+This module provides the metadata accessor for schema version 1.2.1,
+which handles dual entry point configuration while delegating unchanged
+concerns to the v1.2.0 accessor.
+"""
+
+import logging
+from hatch_validator.core.pkg_accessor_base import HatchPkgAccessor as HatchPkgAccessorBase
+
+logger = logging.getLogger("hatch.package.v1_2_1.accessor")
+
+class HatchPkgAccessor(HatchPkgAccessorBase):
+    """Metadata accessor for Hatch package schema version 1.2.1.
+    
+    Adapts access to metadata fields for the v1.2.1 schema structure,
+    specifically handling dual entry point configuration while delegating
+    unchanged concerns to the v1.2.0 accessor.
+    """
+    
+    def can_handle(self, schema_version: str) -> bool:
+        """Check if this accessor can handle schema version 1.2.1.
+        
+        Args:
+            schema_version (str): Schema version to check
+            
+        Returns:
+            bool: True if schema_version is '1.2.1'
+        """
+        return schema_version == "1.2.1"
+    
+    def get_entry_point(self, metadata):
+        """Get entry point from metadata for v1.2.1.
+        
+        Returns the dual entry point object containing both FastMCP server
+        and HatchMCP wrapper file paths.
+        
+        Args:
+            metadata (dict): Package metadata
+            
+        Returns:
+            dict: Dual entry point object with keys:
+                - 'mcp_server': FastMCP server file path
+                - 'hatch_mcp_server': HatchMCP wrapper file path
+                
+        Example:
+            {
+                "mcp_server": "mcp_arithmetic.py",
+                "hatch_mcp_server": "hatch_mcp_arithmetic.py"
+            }
+        """
+        entry_point = metadata.get('entry_point')
+        logger.debug(f"Retrieved dual entry point: {entry_point}")
+        return entry_point

--- a/hatch_validator/package/v1_2_1/entry_point_validation.py
+++ b/hatch_validator/package/v1_2_1/entry_point_validation.py
@@ -1,0 +1,170 @@
+"""Entry point validation strategy for v1.2.1.
+
+This module provides the entry point validation strategy for schema version 1.2.1,
+which validates dual entry point configuration (FastMCP server + HatchMCP wrapper).
+"""
+
+import ast
+import logging
+from pathlib import Path
+from typing import Dict, List, Tuple, Set
+
+from hatch_validator.core.validation_strategy import EntryPointValidationStrategy
+from hatch_validator.core.validation_context import ValidationContext
+
+
+# Configure logging
+logger = logging.getLogger("hatch.schema.v1_2_1.entry_point_validation")
+
+
+class EntryPointValidation(EntryPointValidationStrategy):
+    """Strategy for validating dual entry point files for v1.2.1.
+    
+    This strategy validates that both mcp_server (FastMCP server) and 
+    hatch_mcp_server (HatchMCP wrapper) files exist and that the wrapper
+    properly imports from the FastMCP server.
+    """
+    
+    def validate_entry_point(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate dual entry point according to v1.2.1 schema.
+        
+        Args:
+            metadata (Dict): Package metadata containing entry point information
+            context (ValidationContext): Validation context with resources
+            
+        Returns:
+            Tuple[bool, List[str]]: Tuple containing:
+                - bool: Whether entry point validation was successful
+                - List[str]: List of entry point validation errors
+        """
+        entry_point = metadata.get('entry_point')
+        if not entry_point:
+            logger.error("No entry_point specified in metadata")
+            return False, ["No entry_point specified in metadata"]
+        
+        # Schema validation ensures this is a dict, but double-check
+        if not isinstance(entry_point, dict):
+            logger.error("entry_point must be an object for schema v1.2.1")
+            return False, ["entry_point must be an object for schema v1.2.1"]
+        
+        if not context.package_dir:
+            logger.error("Package directory not provided for entry point validation")
+            return False, ["Package directory not provided for entry point validation"]
+        
+        errors = []
+        
+        # Get both entry point files
+        mcp_server = entry_point.get('mcp_server')
+        hatch_mcp_server = entry_point.get('hatch_mcp_server')
+        
+        # Validate both files exist
+        mcp_server_valid, mcp_server_errors = self._validate_file_exists(mcp_server, context, "FastMCP server")
+        if not mcp_server_valid:
+            errors.extend(mcp_server_errors)
+        
+        hatch_wrapper_valid, hatch_wrapper_errors = self._validate_file_exists(hatch_mcp_server, context, "HatchMCP wrapper")
+        if not hatch_wrapper_valid:
+            errors.extend(hatch_wrapper_errors)
+        
+        # Only validate import relationship if both files exist
+        if mcp_server_valid and hatch_wrapper_valid:
+            import_valid, import_errors = self._validate_import_relationship(
+                mcp_server, hatch_mcp_server, context
+            )
+            if not import_valid:
+                errors.extend(import_errors)
+        
+        if errors:
+            logger.error(f"Entry point validation failed with {len(errors)} errors")
+            return False, errors
+        
+        logger.debug("Dual entry point validation successful")
+        return True, []
+    
+    def _validate_file_exists(self, filename: str, context: ValidationContext, file_type: str) -> Tuple[bool, List[str]]:
+        """Validate that a file exists and is accessible.
+        
+        Args:
+            filename (str): Name of the file to validate
+            context (ValidationContext): Validation context with package directory
+            file_type (str): Type of file for error messages
+            
+        Returns:
+            Tuple[bool, List[str]]: Validation result and errors
+        """
+        if not filename:
+            error_msg = f"{file_type} filename not specified"
+            logger.error(error_msg)
+            return False, [error_msg]
+        
+        file_path = context.package_dir / filename
+        
+        if not file_path.exists():
+            error_msg = f"{file_type} file '{filename}' does not exist"
+            logger.error(error_msg)
+            return False, [error_msg]
+        
+        if not file_path.is_file():
+            error_msg = f"{file_type} '{filename}' is not a file"
+            logger.error(error_msg)
+            return False, [error_msg]
+        
+        # Validate it's a Python file
+        if not filename.endswith('.py'):
+            error_msg = f"{file_type} '{filename}' must be a Python file (.py)"
+            logger.error(error_msg)
+            return False, [error_msg]
+        
+        logger.debug(f"{file_type} file '{filename}' exists and is valid")
+        return True, []
+    
+    def _validate_import_relationship(self, mcp_server: str, hatch_wrapper: str, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate that HatchMCP wrapper imports from FastMCP server.
+        
+        Args:
+            mcp_server (str): FastMCP server filename
+            hatch_wrapper (str): HatchMCP wrapper filename
+            context (ValidationContext): Validation context with package directory
+            
+        Returns:
+            Tuple[bool, List[str]]: Validation result and errors
+        """
+        try:
+            wrapper_path = context.package_dir / hatch_wrapper
+            with open(wrapper_path, 'r', encoding='utf-8') as f:
+                source_code = f.read()
+            
+            # Parse the wrapper file
+            tree = ast.parse(source_code)
+            
+            # Expected import: from mcp_server import mcp (without .py extension)
+            expected_module = mcp_server.replace('.py', '')
+            
+            # Look for the import statement
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom):
+                    if node.module == expected_module:
+                        # Check if 'mcp' is imported
+                        for alias in node.names:
+                            if alias.name == 'mcp':
+                                logger.debug(f"Found valid import: from {expected_module} import mcp")
+                                return True, []
+            
+            # If we get here, the import wasn't found
+            error_msg = f"HatchMCP wrapper must import 'mcp' from '{expected_module}'"
+            suggestion = f"Expected: from {expected_module} import mcp"
+            logger.error(error_msg)
+            return False, [error_msg, suggestion]
+            
+        except SyntaxError as e:
+            error_msg = f"Syntax error in HatchMCP wrapper '{hatch_wrapper}' at line {e.lineno}: {e.msg}"
+            logger.error(error_msg)
+            return False, [error_msg]
+        except FileNotFoundError:
+            error_msg = f"HatchMCP wrapper file '{hatch_wrapper}' not found"
+            logger.error(error_msg)
+            return False, [error_msg]
+        except Exception as e:
+            error_msg = f"Error validating import relationship: {str(e)}"
+            logger.error(error_msg)
+            return False, [error_msg]

--- a/hatch_validator/package/v1_2_1/schema_validation.py
+++ b/hatch_validator/package/v1_2_1/schema_validation.py
@@ -1,0 +1,62 @@
+"""Schema validation strategy for v1.2.1.
+
+This module provides the schema validation strategy for schema version 1.2.1,
+which validates packages against the dual entry point schema.
+"""
+
+import logging
+from typing import Dict, List, Tuple
+
+import jsonschema
+
+from hatch_validator.core.validation_strategy import SchemaValidationStrategy
+from hatch_validator.core.validation_context import ValidationContext
+from hatch_validator.schemas.schemas_retriever import get_package_schema
+
+
+# Configure logging
+logger = logging.getLogger("hatch.schema.v1_2_1.schema_validation")
+
+
+class SchemaValidation(SchemaValidationStrategy):
+    """Strategy for validating metadata against v1.2.1 schema.
+    
+    This strategy validates packages against the v1.2.1 schema which requires
+    dual entry point configuration with mcp_server and hatch_mcp_server fields.
+    """
+    
+    def validate_schema(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate metadata against v1.2.1 schema.
+        
+        Args:
+            metadata (Dict): Package metadata to validate against schema
+            context (ValidationContext): Validation context with resources
+            
+        Returns:
+            Tuple[bool, List[str]]: Tuple containing:
+                - bool: Whether schema validation was successful
+                - List[str]: List of schema validation errors
+        """
+        try:
+            # Load schema for v1.2.1
+            schema = get_package_schema(version="1.2.1", force_update=context.force_schema_update)
+            if not schema:
+                error_msg = "Failed to load package schema version 1.2.1"
+                logger.error(error_msg)
+                return False, [error_msg]
+            
+            # Validate against schema
+            jsonschema.validate(instance=metadata, schema=schema)
+            logger.debug("Package metadata successfully validated against v1.2.1 schema")
+            return True, []
+            
+        except jsonschema.ValidationError as e:
+            error_msg = f"Schema validation failed: {e.message}"
+            if e.absolute_path:
+                error_msg += f" at path: {'.'.join(str(p) for p in e.absolute_path)}"
+            logger.error(error_msg)
+            return False, [error_msg]
+        except Exception as e:
+            error_msg = f"Unexpected error during schema validation: {str(e)}"
+            logger.error(error_msg)
+            return False, [error_msg]

--- a/hatch_validator/package/v1_2_1/tools_validation.py
+++ b/hatch_validator/package/v1_2_1/tools_validation.py
@@ -1,0 +1,157 @@
+"""Tools validation strategy for v1.2.1.
+
+This module provides the tools validation strategy for schema version 1.2.1,
+which enforces that all declared tools must exist in the FastMCP server file
+with proper @mcp.tool() decorators.
+"""
+
+import ast
+import logging
+from typing import Dict, List, Tuple, Set
+
+from hatch_validator.core.validation_strategy import ToolsValidationStrategy
+from hatch_validator.core.validation_context import ValidationContext
+
+
+# Configure logging
+logger = logging.getLogger("hatch.schema.v1_2_1.tools_validation")
+
+
+class ToolsValidation(ToolsValidationStrategy):
+    """Strategy for validating tools with FastMCP server enforcement for v1.2.1.
+    
+    This strategy enforces that ALL tools declared in metadata must exist in the
+    FastMCP server file with proper @mcp.tool() decorators. This ensures tools
+    are available when the FastMCP server is imported independently.
+    """
+    
+    def validate_tools(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate tools according to v1.2.1 schema with FastMCP server enforcement.
+        
+        Args:
+            metadata (Dict): Package metadata containing tool declarations
+            context (ValidationContext): Validation context with resources
+            
+        Returns:
+            Tuple[bool, List[str]]: Tuple containing:
+                - bool: Whether tool validation was successful
+                - List[str]: List of tool validation errors
+        """
+        tools = metadata.get('tools', [])
+        if not tools:
+            logger.debug("No tools declared in metadata")
+            return True, []
+        
+        entry_point = metadata.get('entry_point')
+        if not entry_point or not isinstance(entry_point, dict):
+            logger.error("Dual entry point configuration required for tool validation")
+            return False, ["Dual entry point configuration required for tool validation"]
+        
+        mcp_server_file = entry_point.get('mcp_server')
+        if not mcp_server_file:
+            logger.error("FastMCP server file not specified in entry point")
+            return False, ["FastMCP server file not specified in entry point"]
+        
+        if not context.package_dir:
+            logger.error("Package directory not provided for tool validation")
+            return False, ["Package directory not provided for tool validation"]
+        
+        # Extract tools from FastMCP server file
+        server_tools, extraction_errors = self._extract_fastmcp_tools(mcp_server_file, context)
+        
+        if extraction_errors:
+            logger.error(f"Failed to extract tools from FastMCP server: {extraction_errors}")
+            return False, extraction_errors
+        
+        # Validate all declared tools exist in FastMCP server
+        missing_tools = []
+        for tool in tools:
+            tool_name = tool.get('name')
+            if not tool_name:
+                logger.error(f"Tool metadata missing name: {tool}")
+                missing_tools.append("Tool missing name in metadata")
+                continue
+            
+            if tool_name not in server_tools:
+                logger.error(f"Tool '{tool_name}' not found in FastMCP server '{mcp_server_file}'")
+                missing_tools.append(f"Tool '{tool_name}' not found in FastMCP server '{mcp_server_file}'")
+        
+        if missing_tools:
+            error_msg = "Tools must be defined in FastMCP server to ensure availability when imported independently"
+            missing_tools.append(error_msg)
+            return False, missing_tools
+        
+        logger.debug(f"All {len(tools)} declared tools found in FastMCP server")
+        return True, []
+    
+    def _extract_fastmcp_tools(self, server_file: str, context: ValidationContext) -> Tuple[Set[str], List[str]]:
+        """Extract tool names from @mcp.tool() decorators in FastMCP server file.
+        
+        Args:
+            server_file (str): FastMCP server filename
+            context (ValidationContext): Validation context with package directory
+            
+        Returns:
+            Tuple[Set[str], List[str]]: Set of tool names and list of errors
+        """
+        try:
+            file_path = context.package_dir / server_file
+            if not file_path.exists():
+                error_msg = f"FastMCP server file '{server_file}' not found"
+                logger.error(error_msg)
+                return set(), [error_msg]
+            
+            with open(file_path, 'r', encoding='utf-8') as f:
+                source_code = f.read()
+            
+            tree = ast.parse(source_code)
+            tool_names = set()
+            
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef):
+                    # Check for @mcp.tool() decorator
+                    for decorator in node.decorator_list:
+                        if self._is_mcp_tool_decorator(decorator):
+                            tool_names.add(node.name)
+                            logger.debug(f"Found tool '{node.name}' in FastMCP server")
+                            break
+            
+            logger.debug(f"Extracted {len(tool_names)} tools from FastMCP server: {tool_names}")
+            return tool_names, []
+            
+        except SyntaxError as e:
+            error_msg = f"Syntax error in FastMCP server '{server_file}' at line {e.lineno}: {e.msg}"
+            logger.error(error_msg)
+            return set(), [error_msg]
+        except FileNotFoundError:
+            error_msg = f"FastMCP server file '{server_file}' not found"
+            logger.error(error_msg)
+            return set(), [error_msg]
+        except Exception as e:
+            error_msg = f"Error parsing FastMCP server '{server_file}': {str(e)}"
+            logger.error(error_msg)
+            return set(), [error_msg]
+    
+    def _is_mcp_tool_decorator(self, decorator) -> bool:
+        """Check if decorator is @mcp.tool() or @mcp.tool.
+        
+        Args:
+            decorator: AST decorator node
+            
+        Returns:
+            bool: True if decorator is an MCP tool decorator
+        """
+        # Handle @mcp.tool()
+        if isinstance(decorator, ast.Call):
+            if isinstance(decorator.func, ast.Attribute):
+                return (decorator.func.attr == 'tool' and 
+                        isinstance(decorator.func.value, ast.Name) and 
+                        decorator.func.value.id == 'mcp')
+        
+        # Handle @mcp.tool
+        if isinstance(decorator, ast.Attribute):
+            return (decorator.attr == 'tool' and 
+                    isinstance(decorator.value, ast.Name) and 
+                    decorator.value.id == 'mcp')
+        
+        return False

--- a/hatch_validator/package/v1_2_1/validator.py
+++ b/hatch_validator/package/v1_2_1/validator.py
@@ -1,0 +1,170 @@
+"""Schema validation strategies and validator for v1.2.1.
+
+This module provides concrete implementations of the validation strategies
+and validator for schema version 1.2.1, following the Chain of Responsibility
+and Strategy patterns.
+
+Schema version 1.2.1 introduces dual entry point support with mandatory
+tool enforcement in FastMCP server files.
+"""
+
+import logging
+from typing import Dict, List, Tuple
+
+from hatch_validator.core.validator_base import Validator as ValidatorBase
+from hatch_validator.core.validation_context import ValidationContext
+
+from .schema_validation import SchemaValidation
+from .entry_point_validation import EntryPointValidation
+from .tools_validation import ToolsValidation
+
+
+# Configure logging
+logger = logging.getLogger("hatch.schema.v1_2_1.validator")
+logger.setLevel(logging.INFO)
+
+
+class Validator(ValidatorBase):
+    """Validator for packages using schema version 1.2.1.
+    
+    Schema version 1.2.1 introduces dual entry point support requiring both
+    mcp_server (FastMCP server) and hatch_mcp_server (HatchMCP wrapper) files.
+    This validator implements enhanced entry point and tools validation while
+    delegating unchanged validation logic (dependencies) to the previous validator in the chain.
+    """
+    
+    def __init__(self, next_validator=None):
+        """Initialize the v1.2.1 validator with strategies.
+        
+        Args:
+            next_validator (Validator, optional): Next validator in chain. Defaults to None.
+        """
+        super().__init__(next_validator)
+        self.schema_strategy = SchemaValidation()
+        self.entry_point_strategy = EntryPointValidation()
+        self.tools_strategy = ToolsValidation()
+    
+    def can_handle(self, schema_version: str) -> bool:
+        """Check if this validator can handle the given schema version.
+        
+        Args:
+            schema_version (str): Schema version to check
+            
+        Returns:
+            bool: True if this validator can handle the version, False otherwise
+        """
+        return schema_version == "1.2.1"
+    
+    def validate(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validation entry point for packages following schema v1.2.1.
+        
+        Args:
+            metadata (Dict): Package metadata to validate
+            context (ValidationContext): Validation context with resources and state
+            
+        Returns:
+            Tuple[bool, List[str]]: Tuple containing:
+                - bool: Whether validation was successful
+                - List[str]: List of validation errors
+        """
+        schema_version = metadata.get("package_schema_version", "")
+        
+        # Check if we can handle this version
+        if not self.can_handle(schema_version):
+            if self.next_validator:
+                return self.next_validator.validate(metadata, context)
+            return False, [f"Unsupported schema version: {schema_version}"]
+        
+        logger.info(f"Validating package metadata using v1.2.1 validator")
+        
+        all_errors = []
+        is_valid = True
+        
+        # 1. Validate against JSON schema
+        schema_valid, schema_errors = self.validate_schema(metadata, context)
+        if not schema_valid:
+            all_errors.extend(schema_errors)
+            is_valid = False
+            # If schema validation fails, don't continue with other validations
+            return is_valid, all_errors
+        
+        # 2. Validate dependencies (delegate to v1.2.0 - unchanged)
+        deps_valid, deps_errors = self.validate_dependencies(metadata, context)
+        if not deps_valid:
+            all_errors.extend(deps_errors)
+            is_valid = False
+        
+        # 3. Validate entry point (dual entry point validation)
+        entry_point_valid, entry_point_errors = self.validate_entry_point(metadata, context)
+        if not entry_point_valid:
+            all_errors.extend(entry_point_errors)
+            is_valid = False
+        
+        # 4. Validate tools (enhanced tools validation with FastMCP server enforcement)
+        tools_valid, tools_errors = self.validate_tools(metadata, context)
+        if not tools_valid:
+            all_errors.extend(tools_errors)
+            is_valid = False
+        
+        if is_valid:
+            logger.info("Package metadata validation successful for v1.2.1")
+        else:
+            logger.warning(f"Package metadata validation failed for v1.2.1: {len(all_errors)} errors")
+        
+        return is_valid, all_errors
+    
+    def validate_schema(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate metadata against schema for v1.2.1.
+        
+        Args:
+            metadata (Dict): Package metadata to validate
+            context (ValidationContext): Validation context with resources
+            
+        Returns:
+            Tuple[bool, List[str]]: Validation result and errors
+        """
+        logger.debug("Validating package metadata against v1.2.1 schema")
+        return self.schema_strategy.validate_schema(metadata, context)
+    
+    def validate_dependencies(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate dependencies for v1.2.1.
+        
+        Dependencies structure is unchanged from v1.2.0, so delegate to the next validator.
+        
+        Args:
+            metadata (Dict): Package metadata to validate
+            context (ValidationContext): Validation context with resources
+            
+        Returns:
+            Tuple[bool, List[str]]: Validation result and errors
+        """
+        logger.debug("Delegating dependency validation to v1.2.0 validator")
+        if self.next_validator:
+            return self.next_validator.validate_dependencies(metadata, context)
+        return False, ["No validator available for dependency validation"]
+
+    def validate_entry_point(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate dual entry point for v1.2.1.
+
+        Args:
+            metadata (Dict): Package metadata to validate
+            context (ValidationContext): Validation context with resources
+
+        Returns:
+            Tuple[bool, List[str]]: Validation result and errors
+        """
+        logger.debug("Validating dual entry point for v1.2.1")
+        return self.entry_point_strategy.validate_entry_point(metadata, context)
+
+    def validate_tools(self, metadata: Dict, context: ValidationContext) -> Tuple[bool, List[str]]:
+        """Validate tools with FastMCP server enforcement for v1.2.1.
+
+        Args:
+            metadata (Dict): Package metadata to validate
+            context (ValidationContext): Validation context with resources
+
+        Returns:
+            Tuple[bool, List[str]]: Validation result and errors
+        """
+        logger.debug("Validating tools with FastMCP server enforcement for v1.2.1")
+        return self.tools_strategy.validate_tools(metadata, context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch-validator"
-version = "0.6.3"
+version = "0.7.0"
 authors = [
   { name = "Hatch Team" },
 ]


### PR DESCRIPTION
This pull request adds support for schema version 1.2.1 to the Hatch Validator package, introducing dual entry point validation and stricter tool enforcement. The main changes include registering new accessors and validators for v1.2.1, implementing new validation strategies to handle dual entry points (FastMCP server and HatchMCP wrapper), and ensuring all declared tools are present and properly decorated in the FastMCP server file.

**Support for schema version 1.2.1:**

* Registered the v1.2.1 package accessor and validator in the factories, enabling handling of the new schema version. [[1]](diffhunk://#diff-33167ed757daa2a356c67dc8f5e4aa534e1bd945061343a9847f4b867ee2fe0eR67-R72) [[2]](diffhunk://#diff-2dc3f65efe96615c8493b602dac8e43c1ebd287c5c31c2c2e744d45bf08debc2R70-R75)
* Added documentation and base modules for v1.2.1, describing the dual entry point and tool enforcement requirements. [[1]](diffhunk://#diff-00f48eef679019a81b55743a620283c14f50e982881ad8206e981ebcb971df47R1-R6) [[2]](diffhunk://#diff-ac7dc365a67b5b95d06d4786fa847c5c00ef645dd402d660c661ad89fed3c6d4R1-R54)

**Dual entry point validation:**

* Implemented `EntryPointValidation` strategy for v1.2.1, which validates the existence of both FastMCP server and HatchMCP wrapper files, and checks that the wrapper imports from the server as required.

**Schema and tools validation for v1.2.1:**

* Added `SchemaValidation` strategy for v1.2.1, ensuring package metadata conforms to the new schema with both entry points.
* Implemented `ToolsValidation` strategy for v1.2.1, enforcing that all declared tools exist in the FastMCP server file and are properly decorated with `@mcp.tool()`.
[Copilot is generating a summary...]