### PR TITLE
fix: access to entrypoints

### DIFF
--- a/hatch_validator/core/pkg_accessor_base.py
+++ b/hatch_validator/core/pkg_accessor_base.py
@@ -101,6 +101,43 @@ class HatchPkgAccessor(ABC):
             return self.next_accessor.get_entry_point(metadata)
         raise NotImplementedError("Entry point accessor not implemented for this schema version")
 
+    def get_mcp_entry_point(self, metadata: Dict[str, Any]) -> Any:
+        """Get MCP entry point from metadata.
+
+        Default behavior: delegate to next accessor in chain if available.
+
+        Args:
+            metadata (Dict[str, Any]): Package metadata
+
+        Returns:
+            Any: MCP entry point value
+
+        Raises:
+            NotImplementedError: If there is no next accessor and this method is not overridden
+        """
+        if self.next_accessor:
+            return self.next_accessor.get_mcp_entry_point(metadata)
+        raise NotImplementedError("MCP entry point accessor not implemented for this schema version"
+                                  )
+
+    def get_hatch_mcp_entry_point(self, metadata: Dict[str, Any]) -> Any:
+        """Get Hatch MCP entry point from metadata.
+
+        Default behavior: delegate to next accessor in chain if available.
+
+        Args:
+            metadata (Dict[str, Any]): Package metadata
+
+        Returns:
+            Any: Hatch MCP entry point value
+
+        Raises:
+            NotImplementedError: If there is no next accessor and this method is not overridden
+        """
+        if self.next_accessor:
+            return self.next_accessor.get_hatch_mcp_entry_point(metadata)
+        raise NotImplementedError("Hatch MCP entry point accessor not implemented for this schema version")
+
     def get_tools(self, metadata: Dict[str, Any]) -> Any:
         """Get tools from metadata.
         

--- a/hatch_validator/package/package_service.py
+++ b/hatch_validator/package/package_service.py
@@ -122,6 +122,32 @@ class PackageService:
             raise ValueError("Package metadata is not loaded.")
         return self._accessor.get_entry_point(self._metadata)
 
+    def get_mcp_entry_point(self) -> Any:
+        """Get the MCP entry point from the package metadata.
+
+        Returns:
+            Any: MCP entry point value.
+
+        Raises:
+            ValueError: If metadata is not loaded.
+        """
+        if not self.is_loaded():
+            raise ValueError("Package metadata is not loaded.")
+        return self._accessor.get_mcp_entry_point(self._metadata)
+
+    def get_hatch_mcp_entry_point(self) -> Any:
+        """Get the Hatch MCP entry point from the package metadata.
+
+        Returns:
+            Any: Hatch MCP entry point value.
+
+        Raises:
+            ValueError: If metadata is not loaded.
+        """
+        if not self.is_loaded():
+            raise ValueError("Package metadata is not loaded.")
+        return self._accessor.get_hatch_mcp_entry_point(self._metadata)
+
     def get_tools(self) -> Any:
         """Get the tools from the package metadata.
 

--- a/hatch_validator/package/v1_1_0/accessor.py
+++ b/hatch_validator/package/v1_1_0/accessor.py
@@ -46,6 +46,30 @@ class HatchPkgAccessor(HatchPkgAccessorBase):
     def get_entry_point(self, metadata):
         return metadata.get('entry_point')
 
+    def get_mcp_entry_point(self, metadata):
+        """Until v1.2.1, MCP entry point is the same as the main entry point.
+        Hence, this is equivalent to calling get_entry_point().
+
+        Args:
+            metadata (dict): Package metadata
+
+        Returns:
+            Any: MCP entry point value
+        """
+        return self.get_entry_point(metadata)
+
+    def get_hatch_mcp_entry_point(self, metadata):
+        """For v1.2.1, Hatch MCP entry point is the same as the main entry point.
+        Hence, this is equivalent to calling get_entry_point().
+
+        Args:
+            metadata (dict): Package metadata
+
+        Returns:
+            Any: Hatch MCP entry point value
+        """
+        return self.get_entry_point(metadata)
+
     def get_tools(self, metadata):
         return metadata.get('tools', [])
 

--- a/hatch_validator/package/v1_2_1/accessor.py
+++ b/hatch_validator/package/v1_2_1/accessor.py
@@ -30,25 +30,34 @@ class HatchPkgAccessor(HatchPkgAccessorBase):
         return schema_version == "1.2.1"
     
     def get_entry_point(self, metadata):
-        """Get entry point from metadata for v1.2.1.
-        
-        Returns the dual entry point object containing both FastMCP server
-        and HatchMCP wrapper file paths.
-        
+        """From v1.2.1, returns the same as get_mcp_entry_point().
+
         Args:
             metadata (dict): Package metadata
-            
+
         Returns:
-            dict: Dual entry point object with keys:
-                - 'mcp_server': FastMCP server file path
-                - 'hatch_mcp_server': HatchMCP wrapper file path
-                
-        Example:
-            {
-                "mcp_server": "mcp_arithmetic.py",
-                "hatch_mcp_server": "hatch_mcp_arithmetic.py"
-            }
+            Any: Dual entry point value
         """
-        entry_point = metadata.get('entry_point')
-        logger.debug(f"Retrieved dual entry point: {entry_point}")
-        return entry_point
+        return metadata.get('entry_point').get('mcp_server')
+    
+    def get_mcp_entry_point(self, metadata):
+        """Get MCP entry point from metadata.
+
+        Args:
+            metadata (dict): Package metadata
+
+        Returns:
+            Any: MCP entry point value
+        """
+        return self.get_entry_point(metadata)
+
+    def get_hatch_mcp_entry_point(self, metadata):
+        """Get Hatch MCP entry point from metadata.
+
+        Args:
+            metadata (dict): Package metadata
+
+        Returns:
+            Any: Hatch MCP entry point value
+        """
+        return metadata.get('entry_point').get('hatch_mcp_server')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch-validator"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
   { name = "Hatch Team" },
 ]


### PR DESCRIPTION
The accessor of a package following v1.2.1 of the package metadata schema would return an object containing the two new entry point definitions. But before it was returning a string directly (the name of the file in the package).
Hence the consummers of the API of the validator got broken logic because the return type was not the same anymore.

Fix: Following the pattern of increased coverage of fields via the chain of responsibility, we added virtual functions `get_mcp_entry_point` and `get_hatch_mcp_entry_point` to `pkg_accessor_base.py`.
Then, v1.1.0 implements the default lower level which points to the same as the already existing `get_entry_point`. The accessor for v1.2.0 delegates to v1.1.0.
The accessor for v1.2.1 returns the values associated to the keys `mcp_server` and `hatch_mcp_server` respectively. In addition, the legacy `get_entry_point` points to `mcp_server.py`