### PR TITLE
[v0.9.1] Validator decoupled from `hatch_metadata.json` file I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## <small>0.9.1-dev.1 (2026-04-15)</small>
+
+* fix(validator): decouple validate_package from hatch_metadata.json ([fdfb0f9](https://github.com/CrackingShells/Hatch-Validator/commit/fdfb0f9))
+
 ## 0.9.0 (2026-04-15)
 
 * Merge pull request #20 from HartreeY/feat/schema-v2.0.0-extension ([9c1b618](https://github.com/CrackingShells/Hatch-Validator/commit/9c1b618)), closes [#20](https://github.com/CrackingShells/Hatch-Validator/issues/20)

--- a/hatch_validator/package_validator.py
+++ b/hatch_validator/package_validator.py
@@ -112,16 +112,18 @@ class HatchPackageValidator:
         except Exception as e:
             return False, [f"Error during registry validation: {str(e)}"]
     
-    def validate_package(self, package_dir: Path, pending_update: Optional[Tuple[str, Dict]] = None) -> Tuple[bool, Dict[str, Any]]:
+    def validate_package(self, package_dir: Path, metadata: Optional[Dict[str, Any]] = None, pending_update: Optional[Tuple[str, Dict]] = None) -> Tuple[bool, Dict[str, Any]]:
         """Validate a Hatch package in the specified directory.
-        
+
         Uses the new Chain of Responsibility validator system for comprehensive
         package validation including metadata, dependencies, entry points, and tools.
-        
+
         Args:
             package_dir (Path): Path to the package directory
+            metadata (Dict[str, Any], optional): Pre-extracted flat metadata dict. When supplied,
+                skips file I/O entirely. When absent, loads hatch_metadata.json from package_dir.
             pending_update (Tuple[str, Dict], optional): Optional tuple (pkg_name, metadata) with pending update information. Defaults to None.
-            
+
         Returns:
             Tuple[bool, Dict[str, Any]]: Tuple containing:
                 - bool: Whether validation was successful
@@ -142,22 +144,22 @@ class HatchPackageValidator:
             results['metadata_schema']['errors'].append(f"Package directory does not exist: {package_dir}")
             return False, results
         
-        # Check for metadata file
-        metadata_path = package_dir / "hatch_metadata.json"
-        if not metadata_path.exists():
-            results['valid'] = False
-            results['metadata_schema']['errors'].append("hatch_metadata.json not found")
-            return False, results
-        
-        # Load metadata
-        try:
-            with open(metadata_path, 'r') as f:
-                metadata = json.load(f)
-                results['metadata'] = metadata
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            results['valid'] = False
-            results['metadata_schema']['errors'].append(f"Failed to parse metadata: {e}")
-            return False, results
+        # Load metadata from file if not supplied by caller
+        if metadata is None:
+            metadata_path = package_dir / "hatch_metadata.json"
+            if not metadata_path.exists():
+                results['valid'] = False
+                results['metadata_schema']['errors'].append("hatch_metadata.json not found")
+                return False, results
+            try:
+                with open(metadata_path, 'r') as f:
+                    metadata = json.load(f)
+            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                results['valid'] = False
+                results['metadata_schema']['errors'].append(f"Failed to parse metadata: {e}")
+                return False, results
+
+        results['metadata'] = metadata
         
         # Use new validation system for comprehensive validation
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch-validator"
-version = "0.9.0"
+version = "0.9.1-dev.1"
 description = "Package validator for Hatch packages"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## Overview

Patch release introducing an optional `metadata` keyword argument to
`validate_package()`. Allows callers to supply a pre-extracted flat dict and
bypass disk I/O entirely — the groundwork required for Hatch CLI's upcoming
migration from `hatch_metadata.json` to `server.json` as the package
descriptor.

---

## Bug Fixes

### `validate_package()` hardcoded dependency on `hatch_metadata.json`

**Root cause:** `validate_package()` unconditionally loads `hatch_metadata.json`
from `package_dir`. Once Hatch CLI migrates to `server.json`, that file no
longer exists and every call fails with `"hatch_metadata.json not found"` —
with no way for the caller to supply already-extracted metadata.

**Solution:** Added `metadata: Optional[Dict[str, Any]] = None` between
`package_dir` and `pending_update` in the signature of
`HatchPackageValidator.validate_package()`:

```python
# Before
def validate_package(
    self,
    package_dir: Path,
    pending_update: Optional[Tuple[str, Dict]] = None,
) -> Tuple[bool, Dict[str, Any]]:

# After
def validate_package(
    self,
    package_dir: Path,
    metadata: Optional[Dict[str, Any]] = None,
    pending_update: Optional[Tuple[str, Dict]] = None,
) -> Tuple[bool, Dict[str, Any]]:
```

When `metadata` is supplied, the file-loading block is skipped entirely. When
absent (the default), the existing `hatch_metadata.json` path runs unchanged —
all current callers are backward compatible with no modifications required.

**New caller pattern (Hatch CLI after `server.json` migration):**

```python
metadata = load_package_metadata(pkg_dir)  # extracts + merges from server.json
is_valid, results = validator.validate_package(pkg_dir, metadata=metadata)
```

**Backward compat — existing callers unchanged:**

```python
# Still works exactly as before
is_valid, results = validator.validate_package(package_path)
```
